### PR TITLE
游戏签到重试次数,显示时使用变量值

### DIFF
--- a/gamecheckin.py
+++ b/gamecheckin.py
@@ -84,7 +84,7 @@ class GameCheckin:
         retries = 3
         for i in range(1, retries + 1):
             if i > 1:
-                log.info(f'触发验证码，即将进行第 {i} 次重试，最多 3 次')
+                log.info(f'触发验证码，即将进行第 {i} 次重试，最多 {retries} 次')
             req = http.post(url=self.sign_api, headers=header,
                             json={'act_id': self.act_id, 'region': account[2], 'uid': account[1]})
             if req.status_code == 429:


### PR DESCRIPTION

修改重试次数时发现此处并未使用`retries`，导致修改`retries`后的显示最多仍然是3次