### PR TITLE
调整日志输出格式

### DIFF
--- a/account.py
+++ b/account.py
@@ -12,22 +12,22 @@ def get_account_list(game_id: str, headers: dict, update: bool = False) -> list:
     if update and login.update_cookie_token():
         headers['Cookie'] = config.config['account']['cookie']
     elif update:
-        log.warning(f"获取{game_name}账号列表失败！")
+        log.warning(f"获取「{game_name}」账号列表失败！")
         raise CookieError("BBS Cookie Error")
 
-    log.info(f"正在获取米哈游账号绑定的{game_name}账号列表...")
+    log.info(f"正在获取米哈游账号绑定的「{game_name}」账号列表...")
     response = http.get(setting.account_Info_url, params={"game_biz": game_id}, headers=headers)
     data = response.json()
     if data["retcode"] == -100:
         return get_account_list(game_id, headers, update=True)
 
     if data["retcode"] != 0:
-        log.warning(f"获取{game_name}账号列表失败！")
+        log.warning(f"获取「{game_name}」账号列表失败！")
         return []
 
     account_list = []
     for i in data["data"]["list"]:
         account_list.append([i["nickname"], i["game_uid"], i["region"]])
 
-    log.info(f"已获取到{len(account_list)}个{setting.game_id2name.get(game_id, game_id)}账号信息")
+    log.info(f"已获取到 {len(account_list)} 个「{setting.game_id2name.get(game_id, game_id)}」账号信息")
     return account_list

--- a/cloudgames.py
+++ b/cloudgames.py
@@ -32,8 +32,8 @@ class CloudGenshin:
             send_free_time = int(free_time_data["send_freetime"])
 
             if send_free_time > 0:
-                log.info(f'签到成功，已获得{send_free_time}分钟免费时长')
-                ret_msg += f'签到成功，已获得{send_free_time}分钟免费时长\n'
+                log.info(f'签到成功，已获得 {send_free_time} 分钟免费时长')
+                ret_msg += f'签到成功，已获得 {send_free_time} 分钟免费时长\n'
             else:
                 if free_time < 600:
                     time.sleep(random.randint(3, 6))
@@ -41,20 +41,20 @@ class CloudGenshin:
                     free_time2 = int(data2["data"]["free_time"]["free_time"])
                     if free_time2 > free_time:
                         get_free_time = free_time2 - free_time
-                        log.info(f'签到成功，已获得{get_free_time}分钟免费时长')
-                        ret_msg += f'签到成功，已获得{get_free_time}分钟免费时长\n'
+                        log.info(f'签到成功，已获得 {get_free_time} 分钟免费时长')
+                        ret_msg += f'签到成功，已获得 {get_free_time} 分钟免费时长\n'
                     else:
                         log.info('签到失败，未获得免费时长，可能是已经签到过了或者超出免费时长上限')
                         ret_msg += '签到失败，未获得免费时长，可能是已经签到过了或者超出免费时长上限\n'
-            ret_msg += f'你当前拥有免费时长 {tools.time_conversion(int(data["data"]["free_time"]["free_time"]))} ,' \
+            ret_msg += f'你当前拥有免费时长 {tools.time_conversion(int(data["data"]["free_time"]["free_time"]))}，' \
                        f'畅玩卡状态为 {data["data"]["play_card"]["short_msg"]}，拥有米云币 {data["data"]["coin"]["coin_num"]} 枚'
             log.info(ret_msg)
         elif data['retcode'] == -100:
-            ret_msg = "云原神token失效/防沉迷"
+            ret_msg = "云原神 token 失效/防沉迷"
             log.warning(ret_msg)
             config.clear_cookie_cloudgame_genshin()
         else:
-            ret_msg = f'脚本签到失败，json文本:{req.text}'
+            ret_msg = f'脚本签到失败，json 文本：{req.text}'
             log.warning(ret_msg)
         return ret_msg
 
@@ -76,20 +76,20 @@ class CloudZZZ:
         data = req.json()
         if data['retcode'] == 0:
             if int(data["data"]["free_time"]["send_freetime"]) > 0:
-                log.info(f'签到成功，已获得{data["data"]["free_time"]["send_freetime"]}分钟免费时长')
-                ret_msg += f'签到成功，已获得{data["data"]["free_time"]["send_freetime"]}分钟免费时长\n'
+                log.info(f'签到成功，已获得 {data["data"]["free_time"]["send_freetime"]} 分钟免费时长')
+                ret_msg += f'签到成功，已获得 {data["data"]["free_time"]["send_freetime"]} 分钟免费时长\n'
             else:
                 log.info('签到失败，未获得免费时长，可能是已经签到过了或者超出免费时长上限')
                 ret_msg += '签到失败，未获得免费时长，可能是已经签到过了或者超出免费时长上限\n'
-            ret_msg += f'你当前拥有免费时长 {tools.time_conversion(int(data["data"]["free_time"]["free_time"]))} ,' \
+            ret_msg += f'你当前拥有免费时长 {tools.time_conversion(int(data["data"]["free_time"]["free_time"]))}，' \
                        f'畅玩卡状态为 {data["data"]["play_card"]["short_msg"]}，拥有邦邦点 {data["data"]["coin"]["coin_num"]} 个'
             log.info(ret_msg)
         elif data['retcode'] == -100:
-            ret_msg = "云绝区零token失效/防沉迷"
+            ret_msg = "云绝区零 token 失效/防沉迷"
             log.warning(ret_msg)
             config.clear_cookie_cloudgame_zzz()
         else:
-            ret_msg = f'脚本签到失败，json文本:{req.text}'
+            ret_msg = f'脚本签到失败，json 文本：{req.text}'
             log.warning(ret_msg)
         return ret_msg
 

--- a/competition.py
+++ b/competition.py
@@ -87,7 +87,7 @@ class GeniusInvokation:
         try:
             account_list = account.get_account_list('hk4e_cn', headers)
         except CookieError:
-            log.warning('cookie过期')
+            log.warning('cookie 过期')
             raise CookieError("BBS Cookie Error")
         return account_list
 
@@ -108,7 +108,7 @@ class GeniusInvokation:
             return None
         data = response.json()
         if data['retcode'] == 0:
-            log.info('获取hk4e token成功')
+            log.info('获取 hk4e token 成功')
             self.set_hk4e_token(cookie_get_hk4e_token(''.join(response.headers['Set-Cookie'])))
             user_data = data['data']
             return {"nickname": user_data['nickname'], "game_uid": user_data['game_uid'],
@@ -177,10 +177,10 @@ class GeniusInvokation:
             if task_info['reward']:
                 return ''  # 领取后了应该不需要提示了
             if not task_info['finish']:
-                return f'每周任务:{task_info["task_name"]} 还未完成'
+                return f'每周任务：{task_info["task_name"]} 还未完成'
             if self.get_award(task_info['task_id']):
                 task_info['reward'] = True
-                return f'成功领取每周任务:{task_info["task_name"]} 奖励'
+                return f'成功领取每周任务：{task_info["task_name"]} 奖励'
             return f'无法领取 {task_info["task_name"]} 奖励'
 
         results = ""
@@ -197,7 +197,7 @@ class GeniusInvokation:
         """
         time.sleep(random.randint(3, 8))
         log.info("七圣召唤赛事任务开始")
-        result = '\n七圣召唤比赛: '
+        result = '\n七圣召唤比赛：'
         if not self.user_info:
             log.warning("账号没有绑定任何原神账号！")
             result += "账号没有绑定任何原神账号！"

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ def config_v10_update(data: dict):
     new_keys = ['enable', 'account', 'checkin', 'weekly']
     data['competition']['genius_invokation'] = dict(collections.OrderedDict(
         (key, genius.get(key, False) if key != 'account' else []) for key in new_keys))
-    log.info("config已升级到: 11")
+    log.info("config 已升级到：11")
     return data
 
 
@@ -100,7 +100,7 @@ def config_v11_update(data: dict):
     new_config['cloud_games']['cn']['enable'] = data['cloud_games']['genshin']['enable']
     new_config['cloud_games']['cn']['genshin']['enable'] = data['cloud_games']['genshin']['enable']
     new_config['cloud_games']['cn']['genshin']['token'] = data['cloud_games']['genshin']['token']
-    log.info("config已升级到: 13")
+    log.info("config 已升级到：13")
     return new_config
 
 
@@ -109,7 +109,7 @@ def config_v12_update(data: dict):
     update_config_need = True
     data['version'] = 13
     data['cloud_games']['cn']['zzz'] = {'enable': False, 'token': ""}
-    log.info("config已升级到: 13")
+    log.info("config 已升级到: 13")
     return data
 
 
@@ -122,7 +122,7 @@ def config_v13_update(data: dict):
     new_config['version'] = 14
     new_config['device']['fp'] = config['device'].get('fp', '')
 
-    log.info("config已升级到: 14")
+    log.info("config 已升级到：14")
     return new_config
 
 
@@ -145,7 +145,7 @@ def load_config(p_path=None):
     # 去除cookie最末尾的空格
     data["account"]["cookie"] = str(data["account"]["cookie"]).rstrip(' ')
     config = data
-    log.info("Config加载完毕")
+    log.info("Config 加载完毕")
     return data
 
 
@@ -166,9 +166,9 @@ def save_config(p_path=None, p_config=None):
             f.flush()
         except OSError:
             serverless = True
-            log.info("Cookie保存失败")
+            log.info("Cookie 保存失败")
         else:
-            log.info("Config保存完毕")
+            log.info("Config 保存完毕")
 
 
 def clear_stoken():
@@ -179,7 +179,7 @@ def clear_stoken():
     config["account"]["mid"] = ""
     config["account"]["stuid"] = ""
     config["account"]["stoken"] = "StokenError"
-    log.info("Stoken已删除")
+    log.info("Stoken 已删除")
     save_config()
 
 
@@ -189,7 +189,7 @@ def clear_cookie():
         log.info("云函数执行，无法保存")
         return None
     config["account"]["cookie"] = "CookieError"
-    log.info(f"Cookie已删除")
+    log.info(f"Cookie 已删除")
     save_config()
 
 
@@ -199,7 +199,7 @@ def disable_games(region: str = "cn"):
         log.info("云函数执行，无法保存")
         return None
     config['games'][region]['enable'] = False
-    log.info(f"游戏签到({region})已关闭")
+    log.info(f"游戏签到（{region}）已关闭")
     save_config()
 
 
@@ -210,7 +210,7 @@ def clear_cookie_cloudgame_genshin():
         return None
     config['cloud_games']['cn']['genshin']["enable"] = False
     config['cloud_games']['cn']['genshin']['token'] = ""
-    log.info("国服云原神Cookie删除完毕")
+    log.info("国服云原神 Cookie 删除完毕")
     save_config()
 
 
@@ -221,7 +221,7 @@ def clear_cookie_cloudgame_genshin_os():
         return None
     config['cloud_games']['os']['genshin']["enable"] = False
     config['cloud_games']['os']['genshin']['token'] = ""
-    log.info("国际服云原神Cookie删除完毕")
+    log.info("国际服云原神 Cookie 删除完毕")
     save_config()
 
 
@@ -232,7 +232,7 @@ def clear_cookie_cloudgame_zzz():
         return None
     config['cloud_games']['cn']['zzz']["enable"] = False
     config['cloud_games']['cn']['zzz']['token'] = ""
-    log.info("国服云绝区零Cookie删除完毕")
+    log.info("国服云绝区零 Cookie 删除完毕")
     save_config()
 
 

--- a/docker.py
+++ b/docker.py
@@ -16,7 +16,7 @@ def stop_me(_signo, _stack):
 
 def main():
     signal.signal(signal.SIGINT, stop_me)
-    log.info("使用DOCKER运行米游社签到")
+    log.info("使用 DOCKER 运行米游社签到")
     env = os.environ
     cron_signin = env["CRON_SIGNIN"]
     cron = CronTab(cron_signin, loop=True, random_seconds=True)

--- a/gamecheckin.py
+++ b/gamecheckin.py
@@ -72,7 +72,7 @@ class GameCheckin:
             data = req.json()
             if data["retcode"] == 0:
                 return data["data"]["awards"]
-            log.warning(f"获取签到奖励列表失败，重试次数: {i + 1}")
+            log.warning(f"获取签到奖励列表失败，重试次数：{i + 1}")
             time.sleep(5)  # 等待5秒后重试
         log.warning("获取签到奖励列表失败")
         return []
@@ -103,7 +103,7 @@ class GameCheckin:
                                  json={'act_id': self.act_id, 'region': account[2], 'uid': account[1]})
             if req.status_code == 429:
                 time.sleep(10)  # 429同ip请求次数过多，尝试sleep10s进行解决
-                log.warning('429 Too Many Requests ，即将进入下一次请求')
+                log.warning('429 Too Many Requests，即将进入下一次请求')
                 continue
             data = req.json()
             if data["retcode"] == 0 and data["data"]["success"] == 1 and i < retries:
@@ -128,15 +128,15 @@ class GameCheckin:
         for account in self.account_list:
             if account[1] in config.config["games"]["cn"][self.game_mid]["black_list"]:
                 continue
-            log.info(f"正在为{self.player_name}{account[0]}进行签到...")
+            log.info(f"正在为{self.player_name}「{account[0]}」进行签到...")
             time.sleep(random.randint(2, 8))
             is_data = self.is_sign(region=account[2], uid=account[1])
             if is_data.get("first_bind", False):
-                log.warning(f"{self.player_name}{account[0]}是第一次绑定米游社，请先手动签到一次")
+                log.warning(f"{self.player_name}「{account[0]}」是第一次绑定米游社，请先手动签到一次")
                 continue
             sign_days = is_data["total_sign_day"] - 1
             if is_data["is_sign"]:
-                log.info(f"{self.player_name}{account[0]}今天已经签到过了~\r\n今天获得的奖"
+                log.info(f"{self.player_name}「{account[0]}」今天已经签到过了~\r\n今天获得的奖"
                          f"励是{tools.get_item(self.checkin_rewards[sign_days])}")
                 sign_days += 1
             else:
@@ -146,7 +146,7 @@ class GameCheckin:
                     data = req.json()
                     if data["retcode"] == 0 and data["data"]["success"] == 0:
                         log.info(
-                            f"{self.player_name}{account[0]}签到成功~\r\n今天获得的奖励是"
+                            f"{self.player_name}「{account[0]}」签到成功~\r\n今天获得的奖励是"
                             f"{tools.get_item(self.checkin_rewards[0 if sign_days == 0 else sign_days + 1])}")
                         sign_days += 2
                     elif data["retcode"] == -5003:
@@ -156,7 +156,7 @@ class GameCheckin:
                     else:
                         s = "账号签到失败！"
                         if data["data"] != "" and data.get("data").get("success", -1):
-                            s += "原因: 验证码\njson信息:" + req.text
+                            s += "原因：验证码\njson 信息：" + req.text
                         log.warning(s)
                         return_data += f"\n{account[0]}，触发验证码，本次签到失败"
                         continue
@@ -205,7 +205,7 @@ class Genshin(GameCheckin):
 
 class Honkaisr(GameCheckin):
     def __init__(self):
-        super().__init__("hkrpg_cn", "honkai_sr", "崩坏: 星穹铁道", setting.honkai_sr_act_id, "开拓者")
+        super().__init__("hkrpg_cn", "honkai_sr", "崩坏：星穹铁道", setting.honkai_sr_act_id, "开拓者")
         self.headers["Origin"] = "https://act.mihoyo.com"
         self.init()
 
@@ -227,7 +227,7 @@ def checkin_game(game_name, game_module, game_print_name=""):
         time.sleep(random.randint(2, 8))
         if game_print_name == "":
             game_print_name = game_name
-        log.info(f"正在进行{game_print_name}签到")
+        log.info(f"正在进行「{game_print_name}」签到")
         return_data = f"\n\n{game_module().sign_account()}"
         return return_data
     return ''
@@ -239,7 +239,7 @@ def run_task():
         ("崩坏3rd", "honkai3rd", Honkai3rd),
         ("未定事件簿", "tears_of_themis", TearsOfThemis),
         ("原神", "genshin", Genshin),
-        ("崩坏: 星穹铁道", "honkai_sr", Honkaisr),
+        ("崩坏：星穹铁道", "honkai_sr", Honkaisr),
         ("绝区零", "zzz", ZZZ)
     ]
     return_data = ''

--- a/hoyo_checkin.py
+++ b/hoyo_checkin.py
@@ -56,7 +56,7 @@ def hoyo_checkin(event_base_url: str, act_id: str) -> str:
 
     awards = awards_data.get("data", {}).get("awards")
 
-    log.info(f"准备签到: {today} ")
+    log.info(f"准备签到：{today} ")
 
     # a normal human can't instantly click, so we wait a bit
     sleep_time = random.uniform(2.0, 10.0)
@@ -81,43 +81,43 @@ def hoyo_checkin(event_base_url: str, act_id: str) -> str:
     reward = awards[total_sign_in_day - 1]
 
     log.info("签到成功")
-    log.info(f"\t已连续签到{total_sign_in_day + 1}天")
-    log.info(f"\t今天获得的奖励是: {reward['cnt']}x {reward['name']}")
-    ret_msg = f"\t今天获得的奖励是: {reward['cnt']}x {reward['name']}"
+    log.info(f"\t已连续签到 {total_sign_in_day + 1} 天")
+    log.info(f"\t今天获得的奖励是：{reward['cnt']}x 「{reward['name']}」")
+    ret_msg = f"\t今天获得的奖励是：{reward['cnt']}x 「{reward['name']}」"
     return ret_msg
     # logging.info(f"\tMessage: {response['message']}")
 
 
 def genshin():
-    log.info(f"正在进行原神签到")
-    ret_msg = '原神:\n' + hoyo_checkin("https://sg-hk4e-api.hoyolab.com/event/sol",
+    log.info(f"正在进行「原神」签到")
+    ret_msg = '原神：\n' + hoyo_checkin("https://sg-hk4e-api.hoyolab.com/event/sol",
                                      setting.os_genshin_act_id)
     return ret_msg
 
 
 def honkai_sr():
-    log.info(f"正在进行崩坏:星穹铁道签到")
-    ret_msg = '崩坏:星穹铁道:\n' + hoyo_checkin("https://sg-public-api.hoyolab.com/event/luna/os",
+    log.info(f"正在进行「崩坏：星穹铁道」签到")
+    ret_msg = '崩坏：星穹铁道：\n' + hoyo_checkin("https://sg-public-api.hoyolab.com/event/luna/os",
                                           setting.os_honkai_sr_act_id)
     return ret_msg
 
 
 def honkai3rd():
-    log.info(f"正在进行崩坏3签到")
-    ret_msg = '崩坏3:\n' + hoyo_checkin("https://sg-public-api.hoyolab.com/event/mani",
+    log.info(f"正在进行「崩坏3」签到")
+    ret_msg = '崩坏3：\n' + hoyo_checkin("https://sg-public-api.hoyolab.com/event/mani",
                                       setting.os_honkai3rd_act_id)
     return ret_msg
 
 
 def tears_of_themis():
-    log.info(f"正在进行未定事件簿签到")
-    ret_msg = '未定事件簿:\n' + hoyo_checkin("https://sg-public-api.hoyolab.com/event/luna/os",
+    log.info(f"正在进行「未定事件簿」签到")
+    ret_msg = '未定事件簿：\n' + hoyo_checkin("https://sg-public-api.hoyolab.com/event/luna/os",
                                         setting.os_tearsofthemis_act_id)
     return ret_msg
 
 def zzz():
-    log.info(f"正在进行绝区零签到")
-    ret_msg = '绝区零:\n' + hoyo_checkin("https://sg-act-nap-api.hoyolab.com/event/luna/zzz/os",
+    log.info(f"正在进行「绝区零」签到")
+    ret_msg = '绝区零：\n' + hoyo_checkin("https://sg-act-nap-api.hoyolab.com/event/luna/zzz/os",
                                       setting.os_zzz_act_id)
     return ret_msg
 
@@ -127,7 +127,7 @@ def run_task():
     games = config.config['games']['os']
 
     if games['cookie'] == '':
-        log.warning("国际服未配置Cookie!")
+        log.warning("国际服未配置 Cookie！")
         games['enable'] = False
         config.save_config()
         return ''

--- a/login.py
+++ b/login.py
@@ -15,11 +15,11 @@ headers.pop("Referer")
 
 def login():
     if not config.config["account"]["cookie"]:
-        log.error("请填入Cookies!")
+        log.error("请填入 Cookies！")
         config.clear_cookie()
         raise CookieError('No cookie')
     if config.config['account']['stoken'] == "":
-        log.error("无Stoken 请手动填入stoken!")
+        log.error("无 Stoken 请手动填入 stoken！")
         raise StokenError('no stoken')
     # # 判断Cookie里面是否有login_ticket 没有的话直接退了
     # login_ticket = get_login_ticket()
@@ -29,7 +29,7 @@ def login():
     #     raise CookieError('Cookie lost login_ticket')
     uid = get_uid()
     if uid is None:
-        log.error("cookie缺少UID，请重新抓取bbs的cookie")
+        log.error("cookie 缺少 UID，请重新抓取 bbs 的 cookie")
         config.clear_cookie()
         raise CookieError('Cookie expires')
     config.config["account"]["stuid"] = uid
@@ -37,7 +37,7 @@ def login():
     if require_mid():
         config.config["account"]["mid"] = get_mid()
     log.info("登录成功！")
-    log.info("正在保存Config！")
+    log.info("正在保存 Config！")
     config.save_config()
 
 
@@ -74,14 +74,14 @@ def get_stoken(login_ticket: str, uid: str) -> str:
     if data["retcode"] == 0:
         return data["data"]["list"][0]["token"]
     else:
-        log.error("login_ticket(只有半小时有效期)已失效,请重新登录米游社抓取cookie")
+        log.error("login_ticket（只有半小时有效期）已失效,请重新登录米游社抓取 cookie")
         config.clear_cookie()
         raise CookieError('Cookie expires')
 
 
 def get_cookie_token_by_stoken():
     if config.config["account"]["stoken"] == "" and config.config["account"]["stuid"] == "":
-        log.error("Stoken和Suid为空，无法自动更新CookieToken")
+        log.error("Stoken 和 Suid 为空，无法自动更新 CookieToken")
         config.clear_cookie()
         raise CookieError('Cookie expires')
     header = deepcopy(headers)
@@ -89,18 +89,18 @@ def get_cookie_token_by_stoken():
     data = http.get(url=setting.bbs_get_cookie_token_by_stoken,
                     headers=header).json()
     if data.get("retcode", -1) != 0:
-        log.error("stoken已失效，请重新抓取cookie")
+        log.error("stoken 已失效，请重新抓取 cookie")
         config.clear_stoken()
         raise StokenError('Stoken expires')
     return data["data"]["cookie_token"]
 
 
 def update_cookie_token() -> bool:
-    log.info("CookieToken失效，尝试刷新")
+    log.info("CookieToken 失效，尝试刷新")
     old_token_match = re.search(r'cookie_token=(.*?)(?:;|$)', config.config["account"]["cookie"])
     if old_token_match:
         new_token = get_cookie_token_by_stoken()
-        log.info("CookieToken刷新成功")
+        log.info("CookieToken 刷新成功")
         config.config["account"]["cookie"] = config.config["account"]["cookie"].replace(
             old_token_match.group(1), new_token)
         config.save_config()
@@ -130,7 +130,7 @@ def get_stoken_cookie() -> str:
         if config.config['account']['mid']:
             cookie += f";mid={config.config['account']['mid']}"
         else:
-            log.error(f"v2_stoken需要mid参数")
+            log.error(f"v2_stoken 需要 mid 参数")
             raise CookieError(f"cookie require mid parament")
     return cookie
 
@@ -138,7 +138,7 @@ def get_stoken_cookie() -> str:
 def update_stoken_v2():
     if config.config["account"]["stoken"].startswith("v2_"):
         return
-    log.info("stoken版本为v1，尝试升级为v2")
+    log.info("stoken 版本为 v1，尝试升级为 v2")
     header = deepcopy(headers)
     header["cookie"] = get_stoken_cookie()
     header["x-rpc-app_id"] = "bll8iq97cem8"
@@ -148,9 +148,9 @@ def update_stoken_v2():
         config.config["account"]["stoken"] = stoken_v2
         config.config["account"]["mid"] = data["data"]["user_info"]["mid"]
         config.save_config()
-        log.info("升级stoken成功")
+        log.info("升级 stoken 成功")
     elif data["retcode"] == -100:
-        log.error("stoken已失效，请重新抓取cookie")
+        log.error("stoken 已失效，请重新抓取 cookie")
         config.clear_stoken()
         raise StokenError('Stoken expires')
     else:

--- a/main.py
+++ b/main.py
@@ -19,13 +19,13 @@ from loghelper import log
 def main():
     # 拒绝在GitHub Action运行
     if os.getenv('GITHUB_ACTIONS') == 'true':
-        print("请不要在GitHub Action运行本项目")
+        print("请不要在 GitHub Action 运行本项目")
         exit(0)
     # 初始化，加载配置
     config.load_config()
     if not config.config["enable"]:
-        log.warning("Config未启用！")
-        return 1, "Config未启用！"
+        log.warning("Config 未启用！")
+        return 1, "Config 未启用！"
     # 检测参数是否齐全，如果缺少就进行登入操作
     if any([config.config["account"]["stuid"] == "", config.config["account"]["stoken"] == "",
             login.require_mid() and config.config["account"]["mid"] == ""]):
@@ -50,7 +50,7 @@ def main():
     if config.config["mihoyobbs"]["enable"]:
         if config.config["account"]["stoken"] == "StokenError":
             raise_stoken = True
-            return_data += "米游社: \n账号Stoken异常"
+            return_data += "米游社：\n账号 Stoken 异常"
         else:
             try:
                 bbs = mihoyobbs.Mihoyobbs()
@@ -68,10 +68,10 @@ def main():
         return_data += "\n\n" + cloudgames.run_task()
     # 国际
     if config.config['games']['os']["enable"]:
-        log.info("海外版:")
+        log.info("海外版：")
         os_result = hoyo_checkin.run_task()
         if os_result != '':
-            return_data += "\n\n" + "海外版:" + os_result
+            return_data += "\n\n" + "海外版：" + os_result
     if config.config['cloud_games']['os']["enable"]:
         log.info("正在进行云游戏国际版签到")
         return_data += "\n\n" + os_cloudgames.run_task()
@@ -79,9 +79,9 @@ def main():
         log.info("正在进行米游社竞赛活动签到")
         competition_result = competition.run_task()
         if competition_result != '':
-            return_data += "\n\n" + "米游社竞赛活动:" + competition_result
+            return_data += "\n\n" + "米游社竞赛活动：" + competition_result
     if raise_stoken:
-        raise StokenError("Stoken异常")
+        raise StokenError("Stoken 异常")
     if "触发验证码" in return_data:
         ret_code = 3
     return ret_code, return_data
@@ -94,11 +94,11 @@ if __name__ == "__main__":
         status_code, message = main()
     except CookieError:
         status_code = 1
-        push_message = "账号Cookie出错！\n"
-        log.error("账号Cookie有问题！")
+        push_message = "账号 Cookie 出错！\n"
+        log.error("账号 Cookie 有问题！")
     except StokenError:
         status_code = 1
-        push_message = "账号Stoken出错！\n"
-        log.error("账号Stoken有问题！")
+        push_message = "账号 Stoken 出错！\n"
+        log.error("账号 Stoken 有问题！")
     push_message += message
     push.push(status_code, push_message)

--- a/main_multi.py
+++ b/main_multi.py
@@ -37,7 +37,7 @@ def get_config_list() -> list:
         if os.getenv("QL_DIR") is not None:
             config_list = ql_config(config_list)
     if len(config_list) == 0:
-        log.warning("未检测到配置文件，请确认config文件夹存在.yaml/.yml后缀名的配置文件！")
+        log.warning("未检测到配置文件，请确认 config 文件夹存在 .yaml/.yml 后缀名的配置文件！")
         exit(1)
     return config_list
 
@@ -47,16 +47,16 @@ def main_multi(autorun: bool):
     log.info("正在搜索配置文件！")
     config_list = get_config_list()
     if autorun:
-        log.info(f"已搜索到{len(config_list)}个配置文件，正在开始执行！")
+        log.info(f"已搜索到 {len(config_list)} 个配置文件，正在开始执行！")
     else:
-        log.info(f"已搜索到{len(config_list)}个配置文件，请确认是否无多余文件！\r\n{config_list}")
+        log.info(f"已搜索到 {len(config_list)} 个配置文件，请确认是否无多余文件！\r\n{config_list}")
         try:
-            input("请输入回车继续，需要重新搜索配置文件请Ctrl+C退出脚本")
+            input("请输入回车继续，需要重新搜索配置文件请 Ctrl+C 退出脚本")
         except KeyboardInterrupt:
             exit(0)
     results = {"ok": [], "close": [], "error": [], "captcha": []}
     for i in iter(config_list):
-        log.info(f"正在执行{i}")
+        log.info(f"正在执行 {i}")
         setting.mihoyobbs_List_Use = []
         config.config_Path = f"{config.path}/{i}"
         try:
@@ -70,13 +70,13 @@ def main_multi(autorun: bool):
                 results["captcha"].append(i)
             else:
                 results["close"].append(i)
-        log.info(f"{i}执行完毕")
+        log.info(f"{i} 执行完毕")
         time.sleep(random.randint(3, 10))
     print("")
     push_message = f'脚本执行完毕，共执行{len(config_list)}个配置文件，成功{len(results["ok"])}个，' \
                    f'没执行{len(results["close"])}个，失败{len(results["error"])}个' \
-                   f'\r\n没执行的配置文件: {results["close"]}\r\n执行失败的配置文件: {results["error"]}\r\n' \
-                   f'触发游戏签到验证码的配置文件: {results["captcha"]} '
+                   f'\r\n没执行的配置文件：{results["close"]}\r\n执行失败的配置文件：{results["error"]}\r\n' \
+                   f'触发游戏签到验证码的配置文件：{results["captcha"]}'
     log.info(push_message)
     status = 0
     if len(results["error"]) == len(config_list):

--- a/mihoyobbs.py
+++ b/mihoyobbs.py
@@ -90,7 +90,7 @@ class Mihoyobbs:
         req = http.get(url=setting.bbs_tasks_list, headers=self.headers)
         data = req.json()
         if "err" in data["message"] or data["retcode"] == -100:
-            log.error("获取任务列表失败，你的cookie可能已过期，请重新设置cookie。")
+            log.error("获取任务列表失败，你的 cookie 可能已过期，请重新设置 cookie。")
             config.clear_stoken()
             raise StokenError('Stoken expires')
         self.today_get_coins = data["data"]["can_get_points"]
@@ -120,7 +120,7 @@ class Mihoyobbs:
         if data['data']['can_get_points'] != 0:
             new_day = data['data']['states'][0]['mission_id'] >= 62
             log.info(f"{'新的一天，今天可以获得' if new_day else '似乎还有任务没完成，今天还能获得'}"
-                     f"{self.today_get_coins}个米游币")
+                     f" {self.today_get_coins} 个米游币")
 
     # 获取要帖子列表
     def get_list(self) -> list:
@@ -137,7 +137,7 @@ class Mihoyobbs:
             post = random.choice(data)
             if post["post"]["subject"] not in [x[1] for x in choice_post_list]:
                 choice_post_list.append([post["post"]["post_id"], post["post"]["subject"]])
-        log.info(f"已获取{len(choice_post_list)}个帖子")
+        log.info(f"已获取 {len(choice_post_list)} 个帖子")
         return choice_post_list
 
     # 进行签到操作
@@ -166,11 +166,11 @@ class Mihoyobbs:
                     wait()
                     break
                 elif data["retcode"] == -100:
-                    log.error("签到失败，你的cookie可能已过期，请重新设置cookie。")
+                    log.error("签到失败，你的 cookie 可能已过期，请重新设置 cookie。")
                     config.clear_stoken()
                     raise StokenError('Stoken expires')
                 else:
-                    log.error(f'未知错误: {req.text}')
+                    log.error(f'未知错误：{req.text}')
             if challenge is not None:
                 header.pop("x-rpc-challenge")
 
@@ -229,13 +229,13 @@ class Mihoyobbs:
             if data["message"] == "OK":
                 log.debug(f"分享：{post_info[1]} 成功")
                 break
-            log.debug(f"分享任务执行失败，正在执行第{i + 2}次，共3次")
+            log.debug(f"分享任务执行失败，正在执行第 {i + 2} 次，共 3 次")
             wait()
 
     def post_task(self):
-        log.info("正在执行帖子相关任务(看帖/点赞/分享)......")
+        log.info("正在执行帖子相关任务（看帖/点赞/分享）......")
         if self.task_do["read"] and self.task_do["like"] and self.task_do["share"]:
-            log.info("帖子相关任务(看帖/点赞/分享)已全部完成!")
+            log.info("帖子相关任务（看帖/点赞/分享）已全部完成!")
             return
         # 执行帖子的阅读 点赞 和 分享，其中阅读是必完成的
         for post in self.postsList:
@@ -255,8 +255,8 @@ class Mihoyobbs:
         if self.task_do["sign"] and self.task_do["read"] and self.task_do["like"] and \
                 self.task_do["share"]:
             return_data += "\n" + f"今天已经全部完成了！\n" \
-                                  f"一共获得{self.today_have_get_coins}个米游币\n目前有{self.have_coins}个米游币"
-            log.info(f"今天已经全部完成了！一共获得{self.today_have_get_coins}个米游币，目前有{self.have_coins}个米游币")
+                                  f"一共获得 {self.today_have_get_coins} 个米游币\n目前有 {self.have_coins} 个米游币"
+            log.info(f"今天已经全部完成了！一共获得 {self.today_have_get_coins} 个米游币，目前有 {self.have_coins} 个米游币")
             return return_data
         i = 0
         while self.today_get_coins != 0 and i < 3:
@@ -268,9 +268,9 @@ class Mihoyobbs:
             self.post_task()
             self.get_tasks_list()
             i += 1
-        return_data += "\n" + f"今天已经获得{self.today_have_get_coins}个米游币\n" \
-                              f"还能获得{self.today_get_coins}个米游币\n目前有{self.have_coins}个米游币"
-        log.info(f"今天已经获得{self.today_have_get_coins}个米游币，"
-                 f"还能获得{self.today_get_coins}个米游币，目前有{self.have_coins}个米游币")
+        return_data += "\n" + f"今天已经获得 {self.today_have_get_coins} 个米游币\n" \
+                              f"还能获得 {self.today_get_coins} 个米游币\n目前有 {self.have_coins} 个米游币"
+        log.info(f"今天已经获得 {self.today_have_get_coins} 个米游币，"
+                 f"还能获得 {self.today_get_coins} 个米游币，目前有 {self.have_coins} 个米游币")
         wait()
         return return_data

--- a/os_cloudgames.py
+++ b/os_cloudgames.py
@@ -26,20 +26,20 @@ class CloudGenshin:
         data = req.json()
         if data['retcode'] == 0:
             if int(data["data"]["free_time"]["send_freetime"]) > 0:
-                log.info(f'签到成功，已获得{data["data"]["free_time"]["send_freetime"]}分钟免费时长')
-                ret_msg += f'签到成功，已获得{data["data"]["free_time"]["send_freetime"]}分钟免费时长\n'
+                log.info(f'签到成功，已获得 {data["data"]["free_time"]["send_freetime"]} 分钟免费时长')
+                ret_msg += f'签到成功，已获得 {data["data"]["free_time"]["send_freetime"]} 分钟免费时长\n'
             else:
                 log.info('签到失败，未获得免费时长，可能是已经签到过了或者超出免费时长上限')
                 ret_msg += '签到失败，未获得免费时长，可能是已经签到过了或者超出免费时长上限\n'
-            ret_msg += f'你当前拥有免费时长 {tools.time_conversion(int(data["data"]["free_time"]["free_time"]))} ,' \
+            ret_msg += f'你当前拥有免费时长 {tools.time_conversion(int(data["data"]["free_time"]["free_time"]))}，' \
                        f'畅玩卡状态为 {data["data"]["play_card"]["short_msg"]}，拥有米云币 {data["data"]["coin"]["coin_num"]} 枚'
             log.info(ret_msg)
         elif data['retcode'] == -100:
-            ret_msg = "云原神token失效"
+            ret_msg = "云原神 token 失效"
             log.warning(ret_msg)
             config.clear_cookie_cloudgame_genshin_os()
         else:
-            ret_msg = f'脚本签到失败，json文本:{req.text}'
+            ret_msg = f'脚本签到失败，json 文本：{req.text}'
             log.warning(ret_msg)
         return ret_msg
 

--- a/push.py
+++ b/push.py
@@ -159,7 +159,7 @@ class PushHandler:
                 _image_url = self.http.get("https://api.iw233.cn/api.php?sort=random&type=json").json()["pic"][0]
             except:
                 _image_url = "unable to get the image"
-                log.warning("获取随机背景图失败，请检查图片api")
+                log.warning("获取随机背景图失败，请检查图片 api")
             return _image_url
 
         def get_background_img_html(background_url):

--- a/setting.py
+++ b/setting.py
@@ -29,7 +29,7 @@ game_id2name = {
     "bh3_cn": "崩坏3",
     "nxx_cn": "未定事件簿",
     "hk4e_cn": "原神",
-    "hkrpg_cn": "崩坏： 星穹铁道",
+    "hkrpg_cn": "崩坏：星穹铁道",
     "nap_cn": "绝区零"
 }
 

--- a/tools.py
+++ b/tools.py
@@ -86,11 +86,11 @@ def get_item(raw_data: dict) -> str:
     获取签到的奖励信息
 
     :param raw_data: 签到的奖励数据
-    :return: 签奖励名称x数量
+    :return: 「签奖励名称」x数量
     """
     temp_name = raw_data["name"]
     temp_cnt = raw_data["cnt"]
-    return f"{temp_name}x{temp_cnt}"
+    return f"「{temp_name}」x{temp_cnt}"
 
 
 def get_next_day_timestamp() -> int:
@@ -112,7 +112,7 @@ def time_conversion(minute: int) -> str:
     """
     h = minute // 60
     s = minute % 60
-    return f"{h}小时{s}分钟"
+    return f"{h} 小时 {s} 分钟"
 
 
 def tidy_cookie(cookies: str) -> str:


### PR DESCRIPTION
Close #227

根据 #227 中的建议调整了日志格式。当前日志格式如下：

```
2025-03-02T22:07:01 INFO Config 加载完毕
2025-03-02T22:07:05 INFO 正在进行「崩坏：星穹铁道」签到
2025-03-02T22:07:05 INFO 正在获取米哈游账号绑定的「崩坏：星穹铁道」账号列表...
2025-03-02T22:07:05 INFO 已获取到 1 个「崩坏：星穹铁道」账号信息
2025-03-02T22:07:05 INFO 正在获取签到奖励列表...
2025-03-02T22:07:06 INFO 正在为开拓者「甲乙丙」进行签到...
2025-03-02T22:07:14 INFO 开拓者「甲乙丙ABC」今天已经签到过了~
今天获得的奖励是「冒险记录」x2
```

由于我只玩星铁，无法测试其他游戏，其他日志格式有待进一步测试。

另外，还有一些部分暂不确定是否需要更改，有待探讨：

- [ ] 青龙面板 `ql_main` 和 `push`，我对青龙面板和推送不太熟悉，不确定更改输出是否会产生影响
- [ ] 部分英文大小写没有统一，如 `config`, `Config`, `DOCKER` 等，不确定该采用哪种 case
- [ ] 部分非标准的标点符号，如 `...`/`…` 以及 `~`/`～`