### PR TITLE
feat: cqhttp通知方法支持发送到群聊

### DIFF
--- a/config/push.ini.example
+++ b/config/push.ini.example
@@ -19,9 +19,10 @@ url = https://push.i-i.me/
 
 [cqhttp]
 #cqhttp的服务端地址
-cqhttp_url=http://127.0.0.1:5000/send_private_msg
-#推送给谁
+cqhttp_url=http://127.0.0.1:5000/send_msg
+#推送给QQ号/群号（二选一，勿同时配置）
 cqhttp_qq=10001
+cqhttp_group=10002
 
 [telegram]
 api_url=api.telegram.org

--- a/dacapo_main.py
+++ b/dacapo_main.py
@@ -391,8 +391,9 @@ class DaCapoAdapter:
                 "cqhttp": {
                     "section": "cqhttp",
                     "config": {
-                        "cqhttp_url": "http://127.0.0.1:5000/send_private_msg",
-                        "cqhttp_qq": "10001"
+                        "cqhttp_url": "http://127.0.0.1:5000/send_msg",
+                        "cqhttp_qq": "10001",
+                        "cqhttp_group": "10002"
                     }
                 }
             }

--- a/push.py
+++ b/push.py
@@ -140,12 +140,24 @@ class PushHandler:
         """
         OneBot V11(CqHttp)协议推送
         """
+        qq = self.cfg.get('cqhttp', 'cqhttp_qq')
+        group = self.cfg.get('cqhttp', 'cqhttp_group')
+
+        if qq and group:
+            log.error("请只填写 cqhttp_qq 或 cqhttp_group 的其中一个，不要同时填写！")
+            return
+
+        data = {
+            "message": get_push_title(status_id) + "\r\n" + push_message
+        }
+        if qq:
+            data["user_id"] = int(qq)
+        if group:
+            data["group_id"] = int(group)
+
         self.http.post(
             url=self.cfg.get('cqhttp', 'cqhttp_url'),
-            json={
-                "user_id": self.cfg.getint('cqhttp', 'cqhttp_qq'),
-                "message": get_push_title(status_id) + "\r\n" + push_message
-            }
+            json=data
         )
 
     # 感谢 @islandwind 提供的随机壁纸api 个人主页：https://space.bilibili.com/7600422


### PR DESCRIPTION
改为推荐使用/send_msg，但是实际上 /send_private_msg 和 /send_group_msg 都支持这种发送方式